### PR TITLE
Gradle Plugin with JavaExec task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ sourceCompatibility = 1.6
 targetCompatibility = 1.6
 
 // Release version that won't conflict with the bintray plugin
-def releaseVersion = '1.2.4'
+def releaseVersion = '1.2.5-SNAPSHOT'
 
 group = 'org.liquibase'
 archivesBaseName = 'liquibase-gradle-plugin'
@@ -55,7 +55,7 @@ repositories {
 dependencies {
   compile 'org.codehaus.groovy:groovy:2.4.1'
   compile gradleApi()
-  compile 'org.liquibase:liquibase-core:3.4.2'
+  compile 'org.liquibase:liquibase-core:3.6.1'
 	testCompile 'junit:junit:4.12'
   runtime 'org.liquibase:liquibase-groovy-dsl:1.2.2'
   archives 'org.apache.maven.wagon:wagon-ssh:2.8'

--- a/src/main/groovy/org/liquibase/gradle/LiquibaseExtension.groovy
+++ b/src/main/groovy/org/liquibase/gradle/LiquibaseExtension.groovy
@@ -40,8 +40,6 @@ class LiquibaseExtension {
 
 	String mainClassName = 'liquibase.integration.commandline.Main'
 
-	Configuration classpath
-
   LiquibaseExtension(NamedDomainObjectContainer<Activity> activities) {
     this.activities = activities
   }

--- a/src/main/groovy/org/liquibase/gradle/LiquibaseExtension.groovy
+++ b/src/main/groovy/org/liquibase/gradle/LiquibaseExtension.groovy
@@ -18,6 +18,7 @@
 package org.liquibase.gradle
 
 import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.artifacts.Configuration
 
 /**
  * This is the Gradle extension that configures the Liquibase plugin.  All
@@ -36,6 +37,10 @@ class LiquibaseExtension {
 	 * defined, the plugin will run all activities.
 	 */
 	def runList
+
+	String mainClassName = 'liquibase.integration.commandline.Main'
+
+	Configuration classpath
 
   LiquibaseExtension(NamedDomainObjectContainer<Activity> activities) {
     this.activities = activities

--- a/src/main/groovy/org/liquibase/gradle/LiquibasePlugin.groovy
+++ b/src/main/groovy/org/liquibase/gradle/LiquibasePlugin.groovy
@@ -23,9 +23,11 @@ import org.gradle.api.Plugin
 class LiquibasePlugin
 		implements Plugin<Project> {
 
+	public static final String LIQUIBASE_RUNTIME_CONFIGURATION = "liquibaseRuntime";
 
 	void apply(Project project) {
 		applyExtension(project)
+		applyConfiguration(project)
 		applyTasks(project)
 	}
 
@@ -36,6 +38,12 @@ class LiquibasePlugin
 		}
 		project.configure(project) {
 			extensions.create("liquibase", LiquibaseExtension, activities)
+		}
+	}
+
+	void applyConfiguration(Project project) {
+		project.configure(project) {
+			configurations.maybeCreate(LIQUIBASE_RUNTIME_CONFIGURATION)
 		}
 	}
 

--- a/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
+++ b/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
@@ -112,7 +112,7 @@ class LiquibaseTask extends JavaExec {
 
 		// Set values on the JavaExec task
 		setArgs(args)
-		setClasspath(project.liquibase.classpath)
+		setClasspath(project.configurations.getByName(LiquibasePlugin.LIQUIBASE_RUNTIME_CONFIGURATION))
 		setMain(project.liquibase.mainClassName)
 
 		println "liquibase-plugin: Running the '${activity.name}' activity..."

--- a/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
+++ b/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
@@ -17,8 +17,8 @@
 
 package org.liquibase.gradle
 
-import liquibase.integration.commandline.Main
-import org.gradle.api.DefaultTask
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.TaskAction
 
 /**
@@ -26,7 +26,8 @@ import org.gradle.api.tasks.TaskAction
  *
  * @author Stven C. Saliman
  */
-class LiquibaseTask extends DefaultTask {
+class LiquibaseTask extends JavaExec {
+
 	/**
 	 * The Liquibase command to run.
 	 */
@@ -37,7 +38,8 @@ class LiquibaseTask extends DefaultTask {
 	def requiresValue = false
 
 	@TaskAction
-	def liquibaseAction() {
+	@Override
+	public void exec() {
 
 		def activities = project.liquibase.activities
 		def runList = project.liquibase.runList
@@ -108,9 +110,13 @@ class LiquibaseTask extends DefaultTask {
 			args += value
 		}
 
+		// Set values on the JavaExec task
+		setArgs(args)
+		setClasspath(project.liquibase.classpath)
+		setMain(project.liquibase.mainClassName)
+
 		println "liquibase-plugin: Running the '${activity.name}' activity..."
 		project.logger.debug("liquibase-plugin: Running 'liquibase ${args.join(" ")}'")
-		Main.run(args as String[])
-
+		super.exec()
 	}
 }


### PR DESCRIPTION
Because Liquibase 3.6 started using SLF4J and assumes that Logback will be the implementation, having the dependencies in buildscript is no longer flexible enough (see also issue #10 ).

This pull request changes the task from a DefaultTask to a JavaExec task, leaving the Gradle user free to add a custom configuration to the new classpath property of the LiquibaseExtension.
Additionally, the Main class has been made configurable (with liquibase.integration.commandline.Main as sensible default) to allow for companyspecific default arguments/argument pre-handling.