### PR TITLE
Add support for custom liquibase changelog tables

### DIFF
--- a/src/main/groovy/org/liquibase/gradle/Activity.groovy
+++ b/src/main/groovy/org/liquibase/gradle/Activity.groovy
@@ -30,6 +30,15 @@ class Activity {
 	def arguments = [logLevel: 'info']
 	def parameters = [:]
 
+	/**
+	 * Defines a custom database changelog table to be used.
+	 */
+	String databaseChangeLogTableName
+	/**
+	 * Defines a custom database changelog lock table to be used.
+	 */
+	String databaseChangeLogLockTableName
+
 	Activity(String name) {
 		this.name = name
 	}

--- a/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
+++ b/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
@@ -67,6 +67,15 @@ class LiquibaseTask extends JavaExec {
 	 */
 	def runLiquibase(activity) {
 		def args = []
+
+		// custom liquibase tables need to specified before the command
+		if (activity.databaseChangeLogTableName) {
+			args += "-Dliquibase.databaseChangeLogTableName=${activity.databaseChangeLogTableName}"
+		}
+		if (activity.databaseChangeLogLockTableName) {
+			args += "-Dliquibase.databaseChangeLogLockTableName=${activity.databaseChangeLogLockTableName}"
+		}
+
 		// liquibase forces to add these arguments after the command...
 		def exclusions = ['excludeObjects','includeObjects']
 		activity.arguments.findAll( { !exclusions.contains(it.key) } ) .each {


### PR DESCRIPTION
In a project I'm working on we're using custom names for the liquibase changelog and changelog lock tables.
These need to be specified on the command line with the arguments `-Dliquibase.databaseChangeLogTableName=...` and `-Dliquibase.databaseChangeLogLockTableName=...` but the caveat is that they need to be specified _before_ the command.

This PR adds support for custom tables by adding 2 new properties to an activity: `databaseChangeLogTableName` and `databaseChangeLogLockTableName`.

An example usage would be:
```
liquibase {
    activities {
        main {
            // arguments...
            databaseChangeLogTableName 'LIQUIBASE_CHANGELOG'
            databaseChangeLogLockTableName 'LIQUIBASE_CHANGELOG_LOCK'
        }
    }
}
```