### PR TITLE
Fix using liquibase in non root project and add some configuration properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 // Release version that won't conflict with the bintray plugin
-def releaseVersion = '2.0.5-SNAPSHOT'
+def releaseVersion = '2.0.5-ISBA-1'
 
 group = 'org.liquibase'
 archivesBaseName = 'liquibase-gradle-plugin'

--- a/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
+++ b/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
@@ -46,6 +46,9 @@ class LiquibaseTask extends JavaExec {
 	@Input
 	def runList = ''
 
+	@Input
+	def value = ''
+
 	@TaskAction
 	@Override
 	public void exec() {
@@ -104,6 +107,10 @@ class LiquibaseTask extends JavaExec {
 
 
 		def value = project.properties.get("liquibaseCommandValue")
+
+		if ( !value && this.value != '') {
+			value = this.value
+		}
 
 		// Special case for the dbDoc command.  This is the only command that
 		// has a default value in the plugin.

--- a/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
+++ b/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
@@ -40,12 +40,18 @@ class LiquibaseTask extends JavaExec {
 	@Input
 	def requiresValue = false
 
+	@Input
+	def useDefaultParentProperties = true
+
+	@Input
+	def runList = ''
+
 	@TaskAction
 	@Override
 	public void exec() {
 
 		def activities = project.liquibase.activities
-		def runList = project.liquibase.runList
+		def runList = this.runList? this.runList: project.liquibase.runList
 
 		if ( runList != null && runList.trim().size() > 0 ) {
 			runList.split(',').each { activityName ->
@@ -136,7 +142,10 @@ class LiquibaseTask extends JavaExec {
 		}
 		setClasspath(classpath)
 		// "inherit" the system properties from the Gradle JVM.
-		systemProperties System.properties
+		// This line has been a problem when call liquibase project is not in root project
+		if (useDefaultParentProperties) {
+			systemProperties System.properties
+		}
 		println "liquibase-plugin: Running the '${activity.name}' activity..."
 		project.logger.debug("liquibase-plugin: The ${getMain()} class will be used to run Liquibase")
 		project.logger.debug("liquibase-plugin: Liquibase will be run with the following jvmArgs: ${project.liquibase.jvmArgs}")


### PR DESCRIPTION
I add two properties in LiquibaseTask
 - useDefaultParentProperties allow to skip "inherit" the system properties from the Gradle JVM. by default is false
 - runList can override the project.liquibase.runList. It's optional property, the default value is ''

By default, the behavior is the same than before