### PR TITLE
Improvement: Easier debugging of Liquibase

### DIFF
--- a/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
+++ b/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
@@ -88,7 +88,7 @@ class LiquibaseTask extends JavaExec {
         println "liquibase-plugin: Running the '${activity.name}' activity..."
         project.logger.debug("liquibase-plugin: The ${getMain()} class will be used to run Liquibase")
         project.logger.debug("liquibase-plugin: Liquibase will be run with the following jvmArgs: ${project.liquibase.jvmArgs}")
-        setJvmArgs(project.liquibase.jvmArgs)
+        jvmArgs(project.liquibase.jvmArgs)
         project.logger.debug("liquibase-plugin: Running 'liquibase ${args.join(" ")}'")
         super.exec()
     }


### PR DESCRIPTION
By using `jvmArgs` instead of `setJvmArgs` we keep the `jvmArgs` that were configured on the Gradle task before.

This makes debugging Liquibase itself easier because it allows setting breakpoints in e.g. IntelliJ and simply enabling Gradle script debugging.
IntelliJ will populate jvmArgs with the (random) port where the JDWP server is listening.

Using `setJvmArgs` we overwrite this setting and debugging doesn't work.