### PR TITLE
Use Provider API for main class detection, use `mainClass` instead of `main` (Gradle 8 compatibility)

### DIFF
--- a/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
+++ b/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
@@ -14,8 +14,8 @@
 
 package org.liquibase.gradle
 
-import org.gradle.api.GradleException
 import org.gradle.api.Task
+import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.TaskAction
@@ -135,11 +135,10 @@ class LiquibaseTask extends JavaExec {
             throw new LiquibaseConfigurationException("No liquibaseRuntime dependencies were defined.  You must at least add Liquibase itself as a liquibaseRuntime dependency.")
         }
         setClasspath(classpath)
-        fixMainClass()
         // "inherit" the system properties from the Gradle JVM.
         systemProperties System.properties
         println "liquibase-plugin: Running the '${activity.name}' activity..."
-        project.logger.debug("liquibase-plugin: The ${getMain()} class will be used to run Liquibase")
+        project.logger.debug("liquibase-plugin: The ${mainClass.get()} class will be used to run Liquibase")
         project.logger.debug("liquibase-plugin: Liquibase will be run with the following jvmArgs: ${project.liquibase.jvmArgs}")
         setJvmArgs(project.liquibase.jvmArgs)
         project.logger.debug("liquibase-plugin: Running 'liquibase ${args.join(" ")}'")
@@ -156,9 +155,8 @@ class LiquibaseTask extends JavaExec {
      */
     @Override
     Task configure(Closure closure) {
-        conventionMapping("main") {
-            project.extensions.findByType(LiquibaseExtension.class).mainClassName
-        }
+        fixMainClass(project.configurations.getByName(LiquibasePlugin.LIQUIBASE_RUNTIME_CONFIGURATION).resolvedConfiguration.resolvedArtifacts)
+        mainClass.set(project.extensions.findByType(LiquibaseExtension.class).mainClassName)
         return super.configure(closure)
     }
 
@@ -174,27 +172,23 @@ class LiquibaseTask extends JavaExec {
      * If for some reason, it finds Liquibase in the classpath more than once, the last one it
      * finds, wins.
      */
-    def fixMainClass() {
+    def fixMainClass(Set<ResolvedArtifact> artifacts) {
         if ( project.extensions.findByType(LiquibaseExtension.class).mainClassName ) {
             project.logger.debug("liquibase-plugin: The extension's mainClassName was set, skipping version detection.")
             return
         }
 
-        def foundVersion
-        def config = project.configurations.liquibaseRuntime
-        config.resolvedConfiguration.resolvedArtifacts.each { dep ->
-            def moduleName = dep.moduleVersion.id.name
-            def moduleVersion = dep.moduleVersion.id.version
-            if ( moduleName == 'liquibase-core' ) {
-                project.logger.debug("liquibase-plugin: Found version ${moduleVersion} of liquibase-core.")
-                if ( foundVersion && foundVersion != moduleVersion ) {
-                    project.logger.warn("liquibase-plugin: More than one version of the liquibase-core dependency was found in the liquibaseRuntime configuration!")
-                }
-                foundVersion = moduleVersion
-            }
+        def coreDeps = artifacts.findAll { dep ->
+            dep.moduleVersion.id.name == 'liquibase-core'
         }
+        if (coreDeps.size() > 1) {
+            project.logger.warn("liquibase-plugin: More than one version of the liquibase-core dependency was found in the liquibaseRuntime configuration!")
+        }
+        def foundVersion = coreDeps.last()?.moduleVersion?.id?.version
         if ( !foundVersion ) {
             throw new LiquibaseConfigurationException("Liquibase-core was not found  not found in the liquibaseRuntime configuration!")
+        } else {
+            project.logger.debug("liquibase-plugin: Found version $foundVersion of liquibase-core.")
         }
 
         if ( lbAtLeast(foundVersion, '4.4') ) {

--- a/src/main/groovy/org/liquibase/gradle/Util.groovy
+++ b/src/main/groovy/org/liquibase/gradle/Util.groovy
@@ -14,7 +14,7 @@ class Util {
      * @param targetSemver the target version to use as a comparison.
      * @return @{code true} if the given version is greater than or equal to the target semver.
      */
-    static def versionAtLeast(givenSemver, targetSemver) {
+    static def versionAtLeast(String givenSemver, String targetSemver) {
         List givenVersions = givenSemver.tokenize('.')
         List targetVersions = targetSemver.tokenize('.')
 

--- a/src/test/groovy/org/liquibase/gradle/LiquibasePluginTest.groovy
+++ b/src/test/groovy/org/liquibase/gradle/LiquibasePluginTest.groovy
@@ -122,7 +122,7 @@ class LiquibasePluginTest {
     }
 
     private LiquibaseTask configureForVersion(String version, Closure closure = {}) {
-        project.apply plugin: 'liquibase'
+        project.apply plugin: 'org.liquibase.gradle'
         assertTrue("Project is missing plugin", project.plugins.hasPlugin(LiquibasePlugin))
         project.configurations.getByName(LiquibasePlugin.LIQUIBASE_RUNTIME_CONFIGURATION) {
             dependencies.add(

--- a/src/test/groovy/org/liquibase/gradle/LiquibasePluginTest.groovy
+++ b/src/test/groovy/org/liquibase/gradle/LiquibasePluginTest.groovy
@@ -27,6 +27,8 @@ class LiquibasePluginTest {
     void applyPluginByType() {
         project.apply plugin: org.liquibase.gradle.LiquibasePlugin
         assertTrue("Project is missing plugin", project.plugins.hasPlugin(LiquibasePlugin))
+        project.repositories.configure { mavenCentral() }
+        project.dependencies.add(LiquibasePlugin.LIQUIBASE_RUNTIME_CONFIGURATION, "org.liquibase:liquibase-core:4.4.0")
         // the tag task takes an arg...
         def task = project.tasks.findByName('tag')
         assertNotNull("Project is missing tag task", task)
@@ -49,6 +51,8 @@ class LiquibasePluginTest {
     void applyPluginByName() {
         project.apply plugin: 'liquibase'
         assertTrue("Project is missing plugin", project.plugins.hasPlugin(LiquibasePlugin))
+        project.repositories.configure { mavenCentral() }
+        project.dependencies.add(LiquibasePlugin.LIQUIBASE_RUNTIME_CONFIGURATION, "org.liquibase:liquibase-core:4.4.0")
         // the tag task takes an arg...
         def task = project.tasks.findByName('tag')
         assertNotNull("Project is missing tag task", task)
@@ -74,6 +78,8 @@ class LiquibasePluginTest {
         project.ext.liquibaseTaskPrefix = 'liquibase'
         project.apply plugin: 'liquibase'
         assertTrue("Project is missing plugin", project.plugins.hasPlugin(LiquibasePlugin))
+        project.repositories.configure { mavenCentral() }
+        project.dependencies.add(LiquibasePlugin.LIQUIBASE_RUNTIME_CONFIGURATION, "org.liquibase:liquibase-core:4.4.0")
         // the tag task takes an arg...
         def task = project.tasks.findByName('liquibaseTag')
         assertNotNull("Project is missing tag task", task)
@@ -93,5 +99,42 @@ class LiquibasePluginTest {
         assertNull("We shouldn't have a tag task", task)
         task = project.tasks.findByName('update')
         assertNull("We shouldn't have an update task", task)
+    }
+
+    @Test
+    void checkVersionDetection() {
+        def task = configureForVersion("4.5.0")
+        assertEquals( "liquibase.integration.commandline.LiquibaseCommandLine", task.mainClass.get())
+    }
+
+    @Test
+    void checkVersionDetection_oldVersion() {
+        def task = configureForVersion("4.3.0")
+        assertEquals("liquibase.integration.commandline.Main", task.mainClass.get())
+    }
+
+    @Test
+    void checkVersionDetection_customMainClass() {
+        def task = configureForVersion("4.3.0") {
+            (it.extensions.liquibase as LiquibaseExtension).mainClassName = "com.example.CustomMain"
+        }
+        assertEquals("com.example.CustomMain", task.mainClass.get())
+    }
+
+    private LiquibaseTask configureForVersion(String version, Closure closure = {}) {
+        project.apply plugin: 'liquibase'
+        assertTrue("Project is missing plugin", project.plugins.hasPlugin(LiquibasePlugin))
+        project.configurations.getByName(LiquibasePlugin.LIQUIBASE_RUNTIME_CONFIGURATION) {
+            dependencies.add(
+                    project.dependencies.create("org.liquibase:liquibase-core:$version")
+            )
+        }
+        project.repositories.mavenCentral()
+        closure(project)
+
+        LiquibaseTask task = project.tasks.findByName('update')
+        assertNotNull("Project is missing update task", task)
+        task.configure {}
+        return task
     }
 }


### PR DESCRIPTION
This PR is an attempt to remove usage of deprecated `main` property of `JavaExec` task class in favor of `mainClass`. It also adds a couple of tests on main class name detection, Instead of convention for `main` property, I've tried to analyze dependencies during task configuration and call `mainClass.set` directly.

I've tested it manually on an sample project, everything seems to be working with correct messages in debug logs. This PR closes #91.