### PR TITLE
Fix call to set jvmArgs correctly. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,15 @@ liquibase {
 }
 ```
 
-The `liquibase` block can also set two properties; `mainClassName` and `jvmArgs`.
+The `liquibase` block can also set two properties; `mainClassName` and `jvmArgs`. If you are
+using `liquibase` in a subproject structure, do to a limitation in liquibase, you will need to
+override the `user.dir` using the `jvmArgs`. For example:
+
+```groovy
+liquibase {
+  jvmArgs "-Duser.dir=$project.projectDir" 
+}
+```
 
 The `mainClassName` property tells the plugin the name of the class to invoke in order to run
 Liquibase.  By default, the plugin determines the version of Liquibase being used and sets this

--- a/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
+++ b/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
@@ -88,7 +88,7 @@ class LiquibaseTask extends JavaExec {
         println "liquibase-plugin: Running the '${activity.name}' activity..."
         project.logger.debug("liquibase-plugin: The ${getMain()} class will be used to run Liquibase")
         project.logger.debug("liquibase-plugin: Liquibase will be run with the following jvmArgs: ${project.liquibase.jvmArgs}")
-        setJvmArgs(project.liquibase.jvmArgs)
+        jvmArgs(project.liquibase.jvmArgs)
         project.logger.debug("liquibase-plugin: Running 'liquibase ${args.join(" ")}'")
         super.exec()
     }


### PR DESCRIPTION
Add documentation on how to fix liquibase problem when plugin is used in subproject.

From the documentation of gradle 5.6.3 -> 7.6, the groovy DSL has never supported a setJvmArgs method. Maybe this was done in Kotlin at one time? But this corrects the issue when actually trying to set a JVM arg and getting method not found.

When building with a subproject, liquibase always tries to locate the changelog file in the root dir due to the fact that it's looking in USER_DIR. By being able to override the user.dir, you can set it to a projectDir and get liquibase to now locate the changelog file.