### PR TITLE
Added an 'author' argument for the `DiffChangelogCommand`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # What version of the Liquibase Gradle Plugin are we building?
-liquibaseGradlePluginVersion=2.2.0
+liquibaseGradlePluginVersion=2.2.1
 
 # When we download a maven dependency, should we also get source files?
 downloadSources=false

--- a/src/main/groovy/org/liquibase/gradle/LiquibaseCommand.groovy
+++ b/src/main/groovy/org/liquibase/gradle/LiquibaseCommand.groovy
@@ -16,6 +16,7 @@ abstract class LiquibaseCommand {
     // between Liquibase and this list is that we have a "LABELS" constant to represent the alias
     // created in any command that uses "LABEL_FILTER", and the URL constant had to be named
     // something else to avoid a naming conflict with the URL class.
+    static final AUTHOR = 'author'
     static final AUTO_UPDATE = 'autoUpdate'
     static final CHANGELOG_FILE = 'changelogFile'
     static final CHANGE_EXEC_LISTENER_CLASS = 'changeExecListenerClass'
@@ -140,7 +141,8 @@ abstract class LiquibaseCommand {
             INCLUDE_OBJECTS,
             SQL,
             SQL_FILE,
-            VERBOSE
+            VERBOSE,
+            AUTHOR
     ]
 
     /**

--- a/src/main/groovy/org/liquibase/gradle/liquibase/command/DiffChangelogCommand.groovy
+++ b/src/main/groovy/org/liquibase/gradle/liquibase/command/DiffChangelogCommand.groovy
@@ -48,7 +48,8 @@ class DiffChangelogCommand extends LiquibaseCommand {
                 INCLUDE_CATALOG,
                 DIFF_TYPES,
                 DRIVER,
-                DRIVER_PROPERTIES_FILE
+                DRIVER_PROPERTIES_FILE,
+                AUTHOR
         ]
     }
 


### PR DESCRIPTION
This PR introduces an 'author' argument to support the diff-changelog command in https://github.com/liquibase/liquibase/pull/3990.

I tested it on a Gradle-based project and ran diffChangelog. The changesets' author appears to be functioning correctly with the one I provided.