### PR TITLE
Update README.md to point to the right section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Documentation
 -------------
 
 - [Releases](./doc/releases.md)
-- [How it works](./doc/changelog.md)
+- [How it works](./doc/how-it-works.md)
 - [Usage](./doc/usage.md)
 - [Upgrading Liquibase](./doc/upgrading-liquibase.md)
 


### PR DESCRIPTION
The `How it Works` link the README.md points to the wrong section.