### PR TITLE
fix: input property fingerprinting

### DIFF
--- a/src/main/groovy/org/liquibase/gradle/LiquibaseCommand.groovy
+++ b/src/main/groovy/org/liquibase/gradle/LiquibaseCommand.groovy
@@ -8,7 +8,7 @@ package org.liquibase.gradle
  * @author Steven C. Saliman
  */
 
-abstract class LiquibaseCommand {
+abstract class LiquibaseCommand implements Serializable {
     // These constants represent the known arguments supported by a Liquibase command.  They come
     // from collecting all the CommandArgumentDefinition from CommandSteps in LB.  If you add
     // something here, you must add it to the collection later.  LB uses camelCase in the Java code,

--- a/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
+++ b/src/main/groovy/org/liquibase/gradle/LiquibaseTask.groovy
@@ -15,6 +15,7 @@
 package org.liquibase.gradle
 
 import org.gradle.api.Task
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.JavaExec
@@ -27,11 +28,11 @@ import static org.liquibase.gradle.Util.versionAtLeast
  *
  * @author Stven C. Saliman
  */
-class LiquibaseTask extends JavaExec {
+abstract class LiquibaseTask extends JavaExec {
 
     /** The Liquibase command to run */
     @Input
-    LiquibaseCommand liquibaseCommand
+    abstract Property<LiquibaseCommand> getLiquibaseCommand()
 
     /** a {@code Provider} that can provide a value for the liquibase version. */
     private Provider<String> liquibaseVersionProvider
@@ -73,10 +74,10 @@ class LiquibaseTask extends JavaExec {
         // Set values on the JavaExec task using the Argument Builder appropriate for the Liquibase
         // version we have.
         if ( versionAtLeast(liquibaseVersion, '4.4') ) {
-            setArgs(ArgumentBuilder.buildLiquibaseArgs(project, activity, liquibaseCommand, liquibaseVersion))
+            setArgs(ArgumentBuilder.buildLiquibaseArgs(project, activity, liquibaseCommand.get(), liquibaseVersion))
         } else {
             logger.warn("using legacy argument builder.  Consider updating to Liquibase 4.4+")
-            setArgs(LegacyArgumentBuilder.buildLiquibaseArgs(project, activity, liquibaseCommand, liquibaseVersion))
+            setArgs(LegacyArgumentBuilder.buildLiquibaseArgs(project, activity, liquibaseCommand.get(), liquibaseVersion))
         }
 
         def classpath = project.configurations.getByName(LiquibasePlugin.LIQUIBASE_RUNTIME_CONFIGURATION)

--- a/src/test/groovy/org/liquibase/gradle/LiquibasePluginTest.groovy
+++ b/src/test/groovy/org/liquibase/gradle/LiquibasePluginTest.groovy
@@ -35,13 +35,13 @@ class LiquibasePluginTest {
         assertNotNull("Project is missing tag task", task)
         assertTrue("tag task is the wrong type", task instanceof LiquibaseTask)
         assertTrue("tag task should be enabled", task.enabled)
-        assertEquals("tag task has the wrong command", "tag", task.liquibaseCommand.command)
+        assertEquals("tag task has the wrong command", "tag", task.liquibaseCommand.get().command)
         // and the update task does not.
         task = project.tasks.findByName('update')
         assertNotNull("Project is missing update task", task)
         assertTrue("update task is the wrong type", task instanceof LiquibaseTask)
         assertTrue("update task should be enabled", task.enabled)
-        assertEquals("update task has the wrong command", "update", task.liquibaseCommand.command)
+        assertEquals("update task has the wrong command", "update", task.liquibaseCommand.get().command)
     }
 
     /**
@@ -59,13 +59,13 @@ class LiquibasePluginTest {
         assertNotNull("Project is missing tag task", task)
         assertTrue("tag task is the wrong type", task instanceof LiquibaseTask)
         assertTrue("tag task should be enabled", task.enabled)
-        assertEquals("tag task has the wrong command", "tag", task.liquibaseCommand.command)
+        assertEquals("tag task has the wrong command", "tag", task.liquibaseCommand.get().command)
         // and the update task does not.
         task = project.tasks.findByName('update')
         assertNotNull("Project is missing update task", task)
         assertTrue("update task is the wrong type", task instanceof LiquibaseTask)
         assertTrue("update task should be enabled", task.enabled)
-        assertEquals("update task has the wrong command", "update", task.liquibaseCommand.command)
+        assertEquals("update task has the wrong command", "update", task.liquibaseCommand.get().command)
     }
 
     /**
@@ -86,13 +86,13 @@ class LiquibasePluginTest {
         assertNotNull("Project is missing tag task", task)
         assertTrue("tag task is the wrong type", task instanceof LiquibaseTask)
         assertTrue("tag task should be enabled", task.enabled)
-        assertEquals("tag task has the wrong command", "tag", task.liquibaseCommand.command)
+        assertEquals("tag task has the wrong command", "tag", task.liquibaseCommand.get().command)
         // and the update task does not.
         task = project.tasks.findByName('liquibaseUpdate')
         assertNotNull("Project is missing update task", task)
         assertTrue("update task is the wrong type", task instanceof LiquibaseTask)
         assertTrue("update task should be enabled", task.enabled)
-        assertEquals("update task has the wrong command", "update", task.liquibaseCommand.command)
+        assertEquals("update task has the wrong command", "update", task.liquibaseCommand.get().command)
 
         // Make sure the standard tasks didn't get created, since we created them with different
         // names.


### PR DESCRIPTION
replace a "hardcoded/real" property with a gradle style one so gradle can actually use the input as such

Closes: #120 