### PR TITLE
DAT-21389: Enhance GitHub Actions workflow to configure AWS credentials 

### DIFF
--- a/.github/workflows/publish-to-maven.yml
+++ b/.github/workflows/publish-to-maven.yml
@@ -25,8 +25,25 @@ jobs:
       - name: 'Make gradlew executable'
         run: chmod +x ./gradlew
 
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get secrets from vault
+        id: vault-secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
       - name: 'Create Docker Image, Publish to Registry, and Deploy to Container App'
+        env:
+            MAVEN_USERNAME: ${{ env.SONATYPE_USERNAME }}
+            MAVEN_PASSWORD: ${{ env.SONATYPE_TOKEN }}
         run: |
-          ./gradlew -PmavenCentralUsername=${{ secrets.REPO_USERNAME }} \
-                    -PmavenCentralPassword=${{ secrets.REPO_PASSWORD }} \
+          ./gradlew -PmavenCentralUsername=${MAVEN_USERNAME} \
+                    -PmavenCentralPassword=${MAVEN_PASSWORD} \
                     publish


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing to Maven Central by integrating AWS Secrets Manager for managing sensitive credentials. The main improvements are focused on enhancing security and streamlining the way Maven credentials are handled during the publishing process.

**Security and secrets management:**

* Added steps to configure AWS credentials using the `aws-actions/configure-aws-credentials` action and retrieve Maven credentials from AWS Secrets Manager, replacing the previous use of GitHub secrets for storing Maven Central credentials.

**Workflow improvements:**

* Updated the Docker image build and publish step to use environment variables (`MAVEN_USERNAME` and `MAVEN_PASSWORD`) sourced from AWS Secrets Manager, instead of directly referencing GitHub secrets.